### PR TITLE
Fixing build-ability

### DIFF
--- a/flatpak/com.arteeh.Companion.yml
+++ b/flatpak/com.arteeh.Companion.yml
@@ -1,7 +1,7 @@
 app-id: com.arteeh.Companion
 # Libhandy apparently depends on vala, so the freedesktop platform is not enough
 runtime: org.gnome.Platform
-runtime-version: '3.38'
+runtime-version: '40'
 sdk: org.gnome.Sdk
 command: /app/bin/run.sh
 

--- a/flatpak/com.arteeh.Companion.yml
+++ b/flatpak/com.arteeh.Companion.yml
@@ -50,4 +50,4 @@ modules:
       #- type: git
       #  url: https://gitlab.com/arteeh/wasp-companion.git
       - type: dir
-        path: /home/arteeh/git/wasp-companion
+        path: ..

--- a/flatpak/flatpak
+++ b/flatpak/flatpak
@@ -34,7 +34,7 @@ _modules () {
 _requirements () {
 	# Install requirements
 	flatpak install -y --user org.flatpak.Builder
-	flatpak install -y --user org.gnome.Sdk//3.38
+	flatpak install -y --user org.gnome.Sdk//40
 }
 
 _play () {


### PR DESCRIPTION
As org.gnome.Sdk//3.38 fails downloading, I replaced it with the 40 release. 
I also replaced one hard path by a relative path, so that it would build on my system.

