### PR TITLE
WIP: Implement Running Wasp-Companion in the background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+flatpak/.flatpak-builder
+flatpak/.builddir

--- a/src/app.ui
+++ b/src/app.ui
@@ -131,7 +131,8 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkSpinner">
+                      <object class="GtkSpinner" id="spnInitializing">
+                        <property name="name">spnInitializing</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="valign">start</property>

--- a/src/app.ui
+++ b/src/app.ui
@@ -30,6 +30,22 @@
             <property name="position">0</property>
           </packing>
         </child>
+        <child>
+          <object class="GtkModelButton" id="btnQuit">
+            <property name="name">btnQuit</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="text" translatable="yes">Quit</property>
+            <property name="centered">True</property>
+            <signal name="clicked" handler="_btnQuit" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
       </object>
     </child>
   </object>
@@ -39,7 +55,7 @@
     <property name="window-position">center</property>
     <property name="default-width">500</property>
     <property name="default-height">720</property>
-    <signal name="destroy" handler="_btnQuit" swapped="no"/>
+    <signal name="destroy" handler="_btnClose" swapped="no"/>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>


### PR DESCRIPTION
To run parts of Wasp-Companion in the background (for example: playback controls through wasp-os' music app), I have switched it to use GtkApplication. This allows hold()ing and release()ing the app. Now, when the "x" button is clicked, the app merely destroys the window while other threads continue running. When the app is then started again, the window is simply created again instead of creating a new instance of the app. 
I marked the pull request as WIP though, because I still have to find a way to keep the window state (e.g. if the time is synced) when the window is created again. Simply hiding the window won't work, as the app will just crash for some reason.